### PR TITLE
[GRDM-44131] non-rootユーザーで実行するように変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,8 @@ COPY test.py /usr/bin/test.py
 RUN chmod +x /usr/bin/jupyterhub_users_exporter.py /usr/bin/test.py
 CMD python3 -u /usr/bin/jupyterhub_users_exporter.py
 
+# Create a non-root user
+RUN useradd -m -u 1000 -s /bin/bash user
+USER 1000
+
 EXPOSE 8000


### PR DESCRIPTION
Kubernetesにて、`runAsNonRoot` SecurityContextで実行可能なよう、UID 1000 のユーザー追加を行いました。